### PR TITLE
bug: fix certain tlds not being queried properly

### DIFF
--- a/src/WhoisNET.Client/Program.cs
+++ b/src/WhoisNET.Client/Program.cs
@@ -1,13 +1,16 @@
 ﻿using System.Diagnostics;
+using System.Net.Sockets;
+using System.Text;
 using WhoisNET;
 using WhoisNET.Client.CmdOptions;
 using WhoisNET.Enums;
 using WhoisNET.Parser;
 
 
+
 try
 {
-    //var options = Tokenizer.Tokenize("--verbose 128.14.219.125");
+    //var options = Tokenizer.Tokenize("--verbose --debug free.fr");
     var options = Tokenizer.Tokenize(string.Join(' ', args));
 
     Dictionary<QueryOptions, object> queryOptions = [];

--- a/src/WhoisNET/Whois.cs
+++ b/src/WhoisNET/Whois.cs
@@ -87,7 +87,7 @@ namespace WhoisNET
                 await using TcpHandler tcp = new(server, queryPort);
                 var dataToSend = query;
 
-                dataToSend = $"{CustomQueryCommand(server)}{query}";
+                dataToSend = $"{CustomQueryCommand(server)}{query}".Trim();
 
                 await tcp.WriteAsync(dataToSend);
                 response = await tcp.ReadAsync();
@@ -159,6 +159,7 @@ namespace WhoisNET
             try
             {
                 var hostName = await Dns.GetHostEntryAsync($"{tld}.whois-servers.net");
+      
                 Debug.WriteDebug($"Queried '{tld}.whois-servers.net' and received '{hostName.HostName}'.");
                 return hostName.HostName ?? defaultWhoisServer;
             }


### PR DESCRIPTION
fixes #23
- originally thought this was related to whois-servers.net
- actually because WriteAsync added a CustomQueryCommand added a whitespace in front of the domain